### PR TITLE
Add new date format option for short display

### DIFF
--- a/YOUR_ADMIN/includes/languages/lang.english.php
+++ b/YOUR_ADMIN/includes/languages/lang.english.php
@@ -150,6 +150,7 @@ $define = [
     'DATE_FORMAT_DATE_PICKER' => 'yy-mm-dd',
     'DATE_FORMAT_LONG' => '%A %d %B, %Y',
     'DATE_FORMAT_SHORT' => '%m/%d/%Y',
+    'DATE_FORMAT_SHORT_NO_DAY' => '%B %Y',
     'DATE_FORMAT_SPIFFYCAL' => 'MM/dd/yyyy',
     'DATE_TIME_FORMAT' => '%%DATE_FORMAT_SHORT%%' . ' %H:%M:%S',
     'DEDUCTION_TYPE_DROPDOWN_0' => 'Deduct amount',


### PR DESCRIPTION
Without this extra define, you get the following log file.

[23-Feb-2026 23:32:07 UTC] PHP Fatal error: Uncaught Error: Undefined constant "DATE_FORMAT_SHORT_NO_DAY" in /YOUR_ADMIN/stats_sales_report_graphs.php:260 Stack trace:
#0 /YOUR_ADMIN/index.php(16): require()
#1 {main}
thrown in /YOUR_ADMIN/stats_sales_report_graphs.php on line 260

[23-Feb-2026 23:32:07 UTC] Request URI: /YOUR_ADMIN/index.php?cmd=stats_sales_report_graphs&report=4, IP address: 123.234.43.21 --> PHP Fatal error: Uncaught Error: Undefined constant "DATE_FORMAT_SHORT_NO_DAY" in /YOUR_ADMIN/stats_sales_report_graphs.php:260 Stack trace:
#0 /YOUR_ADMIN/index.php(16): require()
#1 {main}
thrown in /YOUR_ADMIN/stats_sales_report_graphs.php on line 260.

[23-Feb-2026 23:32:07 UTC] Request URI: /YOUR_ADMIN/index.php?cmd=stats_sales_report_graphs&report=4, IP address: 123.234.43.21 --> PHP Fatal error: Uncaught Error: Undefined constant "DATE_FORMAT_SHORT_NO_DAY" in /YOUR_ADMIN/stats_sales_report_graphs.php:260 Stack trace:
#0 /YOUR_ADMIN/index.php(16): require()
#1 {main}
thrown in /YOUR_ADMIN/stats_sales_report_graphs.php on line 260.